### PR TITLE
Breaking change: treat the access token as a secret, do not export it

### DIFF
--- a/src/nodes/config-vrm-api.html
+++ b/src/nodes/config-vrm-api.html
@@ -1,9 +1,14 @@
 <script type="text/javascript">
     RED.nodes.registerType('config-vrm-api',{
         category: 'config',
+        credentials: {
+            token: {
+                type: 'password',
+                validate: RED.validators.regex(/^[a-z0-9]{64}$/)
+            },
+        },
         defaults: {
-            name: { value: "" },
-            token: { value: "", validate: RED.validators.regex(/^[a-z0-9]{64}$/) }    
+            name: { value: "" }
         },
         label: function() {
             return this.name || 'VRM API';

--- a/src/nodes/config-vrm-api.js
+++ b/src/nodes/config-vrm-api.js
@@ -1,9 +1,23 @@
 module.exports = function (RED) {
-  'use strict'
-  function ConfigVRMAPI (n) {
-    RED.nodes.createNode(this, n)
-    this.name = n.name
-    this.token = n.token
-  }
-  RED.nodes.registerType('config-vrm-api', ConfigVRMAPI)
+    'use strict'
+    function ConfigVRMAPI (config) {
+        RED.nodes.createNode(this, config);
+        this.name = config.name;
+
+        // Transfer data from previous versions
+        if (this.credentials && !this.credentials.token && config.token) {
+            RED.nodes.addCredentials(this.id, { token: config.token });
+        }
+
+        // Delete deprecated properties
+        delete config.token;
+        delete this.token;
+    }
+    RED.nodes.registerType('config-vrm-api', ConfigVRMAPI, {
+        credentials: {
+            token: {
+                type: 'password'
+            },
+        },
+    });
 }

--- a/src/nodes/vrm-api.html
+++ b/src/nodes/vrm-api.html
@@ -15,7 +15,7 @@
         paletteLabel: 'VRM API',
         color: '#f7ab3e',
         defaults: {
-            vrm: {value:"", type: "config-vrm-api"},
+            vrm: {value: "", type: "config-vrm-api"},
             name: { value: "" },
             idSite: { value: "", validate: RED.validators.regex(/^[0-9]{1,12}$/)},
             installations: { value: "", required: true},

--- a/src/nodes/vrm-api.js
+++ b/src/nodes/vrm-api.js
@@ -23,7 +23,7 @@ module.exports = function (RED) {
       const options = {
       }
       const headers = {
-        'X-Authorization': 'Token ' + this.vrm.token,
+        'X-Authorization': 'Token ' + this.vrm.credentials.token,
         accept: 'application/json',
         'User-Agent': 'nrc-vrm-api/' + packageJson.version
       }


### PR DESCRIPTION
Attention, this is a breaking change! 
The currently set token will be deleted and must be set again manually.