### PR TITLE
Parameters should start with a question mark

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victron-vrm-api",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Interface with the Victron Energy VRM API",
   "main": "index.js",
   "scripts": {

--- a/src/nodes/vrm-api.js
+++ b/src/nodes/vrm-api.js
@@ -144,7 +144,7 @@ module.exports = function (RED) {
           if (config.instance) {
             parameters.instance = config.instance
           }
-          url += '&' + Object.entries(parameters)
+          url += '?' + Object.entries(parameters)
             .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
             .join('&')
         }


### PR DESCRIPTION
Fix for url generation of widgets api call

currently the first parameter is prefixed with an &. eg: /v2/installations/xxx/widgets/TempSummaryAndGraph&instance=20