### PR TITLE
stats-parameters.js: correct the handling of offsets

### DIFF
--- a/src/utils/stats-parameters.js
+++ b/src/utils/stats-parameters.js
@@ -94,7 +94,7 @@ function buildStatsParameters (config) {
       parameters.end = Math.floor(endOfTomorrow.getTime() / 1000)
     } else if (!isNaN(parseInt(config.stats_end))) {
       // the value is an offset in seconds from now
-      parameters.end = floorToHour(nowTs - parseInt(config.stats_end))
+      parameters.end = floorToHour(nowTs + parseInt(config.stats_end))
     }
   }
 


### PR DESCRIPTION
Offsets are currently not working because the selected offset is subtracted from the end time instead of being added to it. This results in the end time being before the start time, which in turn causes the API to not deliver any data.