### PR TITLE
Add missing "end of tomorrow" option to UI dropdown & Restore “end of yesterday” preset & add explicit “end of year” option

### DIFF
--- a/src/nodes/vrm-api.html
+++ b/src/nodes/vrm-api.html
@@ -234,6 +234,7 @@
                     <option value="eod">end of day</option>
                     <option value="eoy">end of yesterday</option>
                     <option value="eot">end of tomorrow</option>
+                    <option value="eoyr">end of year</option>
                     <option selected="selected" value="86400">+24 hours</option>
     ### tfx add more interval options
                     <option selected="selected" value="172800">+48 hours</option>

--- a/src/utils/stats-parameters.js
+++ b/src/utils/stats-parameters.js
@@ -68,7 +68,7 @@ function buildStatsParameters (config) {
   }
 
   // Set end time
-  if (config.stats_end) {      // interpret 'eod', 'eoy', and 'eot'
+  if (config.stats_end) {      // interpret 'eod', 'eoy', 'eot', and 'eoyr'
     if (config.stats_end === 'eod') {
       const endOfDay = new Date(now)
       // Set to start of next day (24:00:00 = 00:00:00 + 1 day) for API preference
@@ -80,8 +80,14 @@ function buildStatsParameters (config) {
       }
       parameters.end = Math.floor(endOfDay.getTime() / 1000)
     } else if (config.stats_end === 'eoy') {
-      const endOfYear = new Date(now.getFullYear(), 11, 31, 23, 59, 59, 999)
-      parameters.end = Math.floor(endOfYear.getTime() / 1000)
+      const endOfYesterday = new Date(now)
+      endOfYesterday.setDate(endOfYesterday.getDate() - 1)
+      if (config.use_utc) {
+        endOfYesterday.setUTCHours(23, 59, 59, 999)
+      } else {
+        endOfYesterday.setHours(23, 59, 59, 999)
+      }
+      parameters.end = Math.floor(endOfYesterday.getTime() / 1000)
     } else if (config.stats_end === 'eot') {
       // End of tomorrow
       const endOfTomorrow = new Date(now)
@@ -92,6 +98,16 @@ function buildStatsParameters (config) {
         endOfTomorrow.setHours(23, 59, 59, 999)
       }
       parameters.end = Math.floor(endOfTomorrow.getTime() / 1000)
+    } else if (config.stats_end === 'eoyr') {
+      const endOfYear = new Date(now)
+      if (config.use_utc) {
+        endOfYear.setUTCFullYear(now.getUTCFullYear(), 11, 31)
+        endOfYear.setUTCHours(23, 59, 59, 999)
+      } else {
+        endOfYear.setFullYear(now.getFullYear(), 11, 31)
+        endOfYear.setHours(23, 59, 59, 999)
+      }
+      parameters.end = Math.floor(endOfYear.getTime() / 1000)
     } else if (!isNaN(parseInt(config.stats_end))) {
       // the value is an offset in seconds from now
       parameters.end = floorToHour(nowTs + parseInt(config.stats_end))

--- a/test/unit/build-stats-parameters.test.js
+++ b/test/unit/build-stats-parameters.test.js
@@ -208,7 +208,7 @@ describe('buildStatsParameters', () => {
       expect(result.end).toBe(expectedEnd)
     })
 
-    it('should handle "eoy" (end of year) end time', () => {
+    it('should handle "eoy" (end of yesterday) end time', () => {
       const config = {
         attribute: 'Dc/0/Power',
         stats_end: 'eoy'
@@ -216,8 +216,57 @@ describe('buildStatsParameters', () => {
 
       const result = buildStatsParameters(config)
       
-      // Should be end of 2023
-      const expectedEnd = Math.floor(new Date(2023, 11, 31, 23, 59, 59, 999).getTime() / 1000)
+      const endOfYesterday = new Date(fixedDate)
+      endOfYesterday.setDate(endOfYesterday.getDate() - 1)
+      endOfYesterday.setHours(23, 59, 59, 999)
+      const expectedEnd = Math.floor(endOfYesterday.getTime() / 1000)
+      expect(result.end).toBe(expectedEnd)
+    })
+
+    it('should handle "eoy" end time with UTC enabled', () => {
+      const config = {
+        attribute: 'Dc/0/Power',
+        stats_end: 'eoy',
+        use_utc: true
+      }
+
+      const result = buildStatsParameters(config)
+
+      const endOfYesterday = new Date(fixedDate)
+      endOfYesterday.setDate(endOfYesterday.getDate() - 1)
+      endOfYesterday.setUTCHours(23, 59, 59, 999)
+      const expectedEnd = Math.floor(endOfYesterday.getTime() / 1000)
+      expect(result.end).toBe(expectedEnd)
+    })
+
+    it('should handle "eoyr" (end of year) end time', () => {
+      const config = {
+        attribute: 'Dc/0/Power',
+        stats_end: 'eoyr'
+      }
+
+      const result = buildStatsParameters(config)
+
+      const endOfYear = new Date(fixedDate)
+      endOfYear.setFullYear(endOfYear.getFullYear(), 11, 31)
+      endOfYear.setHours(23, 59, 59, 999)
+      const expectedEnd = Math.floor(endOfYear.getTime() / 1000)
+      expect(result.end).toBe(expectedEnd)
+    })
+
+    it('should handle "eoyr" end time with UTC enabled', () => {
+      const config = {
+        attribute: 'Dc/0/Power',
+        stats_end: 'eoyr',
+        use_utc: true
+      }
+
+      const result = buildStatsParameters(config)
+
+      const endOfYear = new Date(fixedDate)
+      endOfYear.setUTCFullYear(endOfYear.getUTCFullYear(), 11, 31)
+      endOfYear.setUTCHours(23, 59, 59, 999)
+      const expectedEnd = Math.floor(endOfYear.getTime() / 1000)
       expect(result.end).toBe(expectedEnd)
     })
 


### PR DESCRIPTION
The End dropdown in vrm-api.html is missing the "end of tomorrow" (eot) option that is already supported by the parser in stats-parameters.js.

This commit adds the missing "end of tomorrow" option to the End dropdown, enabling the use case: Start "beginning of tomorrow" + End "end of tomorrow" for retrieving complete next-day forecasts.

Revert stats_end: eoy to behave as it did before commit 253df7160347fe2c2683ac9adcdfd58001478d8b (i.e. ending at yesterday 23:59:59) so historical flows work unchanged.

Introduce a new stats_end: eoyr key that preserves the end-of-year calculation added in that commit, covering the newer “This year” use case.

Surface the new option in the stats dropdown and extend unit coverage (local/UTC) for both presets.